### PR TITLE
python: fix TypeError when the _vim_path_ import hook is triggered

### DIFF
--- a/runtime/autoload/provider/script_host.py
+++ b/runtime/autoload/provider/script_host.py
@@ -238,11 +238,11 @@ def discover_runtime_directories(nvim):
     for path in nvim.list_runtime_paths():
         if not os.path.exists(path):
             continue
-        path1 = os.path.join(path, b'pythonx')
+        path1 = os.path.join(path, 'pythonx')
         if IS_PYTHON3:
-            path2 = os.path.join(path, b'python3')
+            path2 = os.path.join(path, 'python3')
         else:
-            path2 = os.path.join(path, b'python2')
+            path2 = os.path.join(path, 'python2')
         if os.path.exists(path1):
             rv.append(path1)
         if os.path.exists(path2):


### PR DESCRIPTION
When trying to import a non-existent module, or one that has been added
to `sys.path` after `_vim_path_`, this triggers the `path_hook`, where
`discover_runtime_directories` returned byte strings for the special
directories.

This fixes TypeError("Can't mix strings and bytes in path components",)

```
TypeError("Can't mix strings and bytes in path components",)
Traceback (most recent call last):
  File "…/nvim-python-client/neovim/msgpack_rpc/session.py", line 168, in handler
    rv = self._request_cb(name, args)
  File "…/nvim-python-client/neovim/api/common.py", line 229, in filter_request_cb
    walk(self._in, args, self, name, 'request'))
  File "…/nvim-python-client/neovim/plugin/host.py", line 65, in _on_request
    rv = handler(*args)
  File "/usr/local/share/nvim/runtime/autoload/provider/script_host.py", line 77, in python_execute
    exec(script, self.module.__dict__)
  File "<string>", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2222, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 2164, in _find_spec
  File "<frozen importlib._bootstrap>", line 1940, in find_spec
  File "<frozen importlib._bootstrap>", line 1916, in _get_spec
  File "<fr
```
